### PR TITLE
Unify tooling: canonical air.toml, minimal .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-.RData
-.Rcheck
-.Rhistory
-.Rproj.user
-docs/
+# This file intentionally minimal — see ~/.config/git/ignore for global patterns.


### PR DESCRIPTION
- Standardize air.toml to Variant A (default-exclude=false, line-ending=lf)
- Replace .gitignore with minimal version (global ~/.config/git/ignore covers .RData, .Rcheck, docs/, _problems/)